### PR TITLE
Improve README: don't use model term in place of record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Activerecord-prunable [![Gem Version](https://badge.fury.io/rb/activerecord-prunable.svg)](https://badge.fury.io/rb/activerecord-prunable) [![Build Status](https://travis-ci.org/dr2m/activerecord-prunable.svg?branch=master)](https://travis-ci.org/dr2m/activerecord-prunable) [![Code Climate](https://codeclimate.com/github/dr2m/activerecord-prunable/badges/gpa.svg)](https://codeclimate.com/github/dr2m/activerecord-prunable)  
+# Activerecord-prunable [![Gem Version](https://badge.fury.io/rb/activerecord-prunable.svg)](https://badge.fury.io/rb/activerecord-prunable) [![Build Status](https://travis-ci.org/dr2m/activerecord-prunable.svg?branch=master)](https://travis-ci.org/dr2m/activerecord-prunable) [![Code Climate](https://codeclimate.com/github/dr2m/activerecord-prunable/badges/gpa.svg)](https://codeclimate.com/github/dr2m/activerecord-prunable)
 
-Convenient removal of obsolete ActiveRecord models.
+Convenient removal of obsolete records for ActiveRecord models.
 
 ## Installation
 
@@ -21,9 +21,9 @@ Or install it yourself as:
 
 ## Usage
 
-__1. Include the `Prunable` module in the ActiveRecord model which needs to be pruned.__  
+__1. Include the `Prunable` module in the ActiveRecord model which needs to be pruned.__
 
-__2. Define the `:prunable` scope which returns models to prune.__
+__2. Define the `:prunable` scope which returns records to prune.__
 
    ```ruby
    class Notification < ApplicationRecord
@@ -37,7 +37,7 @@ __2. Define the `:prunable` scope which returns models to prune.__
    end
    ```
 
-   or use one of the `prune_after`, `prune_created_after`, `prune_updated_after` methods  
+   or use one of the `prune_after`, `prune_created_after`, `prune_updated_after` methods
 
    ```ruby
    class Notification < ApplicationRecord
@@ -47,9 +47,9 @@ __2. Define the `:prunable` scope which returns models to prune.__
    end
    ```
 
-   `prune_after` is an alias for `prune_created_after`  
-   `prune_created_after(TTL)` defines `where('created_at < ?', current_time - TTL)` prunable scope  
-   `prune_updated_after(TTL)` defines `where('updated_at < ?', current_time - TTL)` prunable scope  
+   `prune_after` is an alias for `prune_created_after`
+   `prune_created_after(TTL)` defines `where('created_at < ?', current_time - TTL)` prunable scope
+   `prune_updated_after(TTL)` defines `where('updated_at < ?', current_time - TTL)` prunable scope
 
 __3. Add a `Prunable.prune!` call to a periodic task.__
 
@@ -71,31 +71,31 @@ __Pruning a single model:__
 SomeModel.prune!
 ```
 
-__Pruning multiple models:__  
-Note that the `Prunable.prune!` calls `Rails.application.eager_load!`. It can decrease free memory size.  
+__Pruning multiple models:__
+Note that the `Prunable.prune!` calls `Rails.application.eager_load!`. It can decrease free memory size.
 
 ```ruby
 Prunable.prune!(SomeModel, AnotherModel)
 ```
 
-__Set default method of pruning (:destroy or :delete):__  
+__Set default method of pruning (:destroy or :delete):__
 
 ```ruby
 Prunable.prune!(prune_method: :delete)
 ```
 
-__Call `:prunable` scope with params:__  
+__Call `:prunable` scope with params:__
 
 ```ruby
 Prunable.prune!(params: [:foo, :bar])
 ```
 
-__Getting an array of all the models which include `ActiveRecord::Prunable`:__  
+__Getting an array of all the models which include `ActiveRecord::Prunable`:__
 ```ruby
 Prunable.models
 ```
 
-__Pruning all models which include `ActiveRecord::Prunable`:__  
+__Pruning all models which include `ActiveRecord::Prunable`:__
 
 ```ruby
 Prunable.prune!


### PR DESCRIPTION
Hi Nikita!

Thank you for your gem!
I've just noticed, that sometimes you use the term model in place of record, of model instance.
It might be confusing, because people might think that the gem removes the whole tables and models code, which is of course nonsense.
So I edited README a bit.

If you decide merge my PR, please edit a project header as well.

All the best to you!